### PR TITLE
Add `before_execute` and `after_execute` hooks

### DIFF
--- a/lib/super_docopt/base.rb
+++ b/lib/super_docopt/base.rb
@@ -5,8 +5,7 @@ module SuperDocopt
   class Base
     include Singleton
 
-    VERSION = '0.0.1'
-
+    attr_reader :args
     attr_accessor :version, :docopt, :subcommands
 
     def self.execute(argv=[])
@@ -24,12 +23,12 @@ module SuperDocopt
     def self.subcommands(list)
       instance.subcommands = list
     end
-    
+
     def execute_cli(argv=[])
       doc = File.read docopt
       begin
-        args = Docopt::docopt(doc, argv: argv, version: version)
-        handle_subcommand args
+        @args = Docopt::docopt(doc, argv: argv, version: version)
+        handle_subcommand
       rescue Docopt::Exit => e
         puts e.message
       end
@@ -37,24 +36,20 @@ module SuperDocopt
 
     private
 
-    def handle_subcommand(args)
+    def handle_subcommand
       subcommands.each do |subcommand|
         input, method = translate_subcommand subcommand
-        found = find_and_execute args, input, method
-        return if found
+        return execute_subcommand input, method if args[input] 
       end
     end
 
-    def find_and_execute(args, input, method)
-      if args[input]
-        raise NotImplementedError, 
-          "Please implement ##{method}" unless respond_to? method
+    def execute_subcommand(input, method)
+      raise NotImplementedError, 
+        "Please implement ##{method}" unless respond_to? method
 
-        before_execute args
-        send method, args
-        after_execute args
-        return
-      end
+      before_execute
+      send method
+      after_execute
     end
 
     def translate_subcommand(subcommand)
@@ -72,9 +67,9 @@ module SuperDocopt
       [input, method]
     end
 
-    # Overridables
+    # Overridable Hooks
 
-    def before_execute(args); end
-    def after_execute(args); end
+    def before_execute; end
+    def after_execute; end
   end
 end

--- a/lib/super_docopt/base.rb
+++ b/lib/super_docopt/base.rb
@@ -50,7 +50,9 @@ module SuperDocopt
         raise NotImplementedError, 
           "Please implement ##{method}" unless respond_to? method
 
+        before_execute args
         send method, args
+        after_execute args
         return
       end
     end
@@ -69,5 +71,10 @@ module SuperDocopt
 
       [input, method]
     end
+
+    # Overridables
+
+    def before_execute(args); end
+    def after_execute(args); end
   end
 end

--- a/spec/fixtures/check
+++ b/spec/fixtures/check
@@ -1,1 +1,3 @@
-#verify called
+#before_execute called
+#verify called to initialize variable
+#after_execute called

--- a/spec/fixtures/hello
+++ b/spec/fixtures/hello
@@ -1,1 +1,3 @@
+#before_execute called
 #hello called with {"hello"=>true, "not-implemented"=>false, "check"=>false, "just-do-it"=>false, "-h"=>false, "--help"=>false, "--version"=>false}
+#after_execute called

--- a/spec/fixtures/just_do_it
+++ b/spec/fixtures/just_do_it
@@ -1,1 +1,3 @@
+#before_execute called
 #just_do_it called
+#after_execute called

--- a/spec/mocks/basic_cli.rb
+++ b/spec/mocks/basic_cli.rb
@@ -9,12 +9,21 @@ module SuperDocopt::Mocks
       {'check' => :verify}
     ]
 
+    def before_execute(args)
+      @good_place = "to initialize variable"
+      puts "#before_execute called"
+    end
+
+    def after_execute(args)
+      puts "#after_execute called"
+    end
+
     def hello(args)
       puts "#hello called with #{args}"
     end
 
     def verify(args)
-      puts "#verify called"
+      puts "#verify called #{@good_place}"
     end
 
     def just_do_it(args)

--- a/spec/mocks/basic_cli.rb
+++ b/spec/mocks/basic_cli.rb
@@ -9,24 +9,24 @@ module SuperDocopt::Mocks
       {'check' => :verify}
     ]
 
-    def before_execute(args)
+    def before_execute
       @good_place = "to initialize variable"
       puts "#before_execute called"
     end
 
-    def after_execute(args)
+    def after_execute
       puts "#after_execute called"
     end
 
-    def hello(args)
+    def hello
       puts "#hello called with #{args}"
     end
 
-    def verify(args)
+    def verify
       puts "#verify called #{@good_place}"
     end
 
-    def just_do_it(args)
+    def just_do_it
       puts "#just_do_it called"      
     end
   end


### PR DESCRIPTION
This PR adds `before_execute` and `after_execute` overridable hooks.

In addition, arg handling was refactored so taht subclasses no longer need to have the `args` argument in each of the subcommand hooks, it will be available as an instance variable.