### PR TITLE
Maintenance update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,13 @@
 language: ruby
 
-env:
-  global:
-  - CC_TEST_REPORTER_ID=395e26e0bbd130ac4c78684849bd16274e79fa71d5f2641ed7dcd88d30255dd7
-
 rvm:
-  - "2.2.2"
-  - "2.4.2"
+  - "2.3.0"
+  - "2.4.0"
   - "2.5.0"
+  - "2.6.0"
 
 before_install:
 - gem install bundler
 
-before_script:
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-- chmod +x ./cc-test-reporter
-- ./cc-test-reporter before-build
-
 script:
 - bundle exec rspec
-
-after_script: 
-- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 source "https://rubygems.org"
 
+gem 'byebug'
+gem 'requires'
+gem 'rspec'
+gem 'rspec_fixtures'
+gem 'runfile'
+gem 'runfile-tasks'
+gem 'simplecov'
+
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Super Docopt
 [![Gem Version](https://badge.fury.io/rb/super_docopt.svg)](https://badge.fury.io/rb/super_docopt)
 [![Build Status](https://travis-ci.com/DannyBen/super_docopt.svg?branch=master)](https://travis-ci.com/DannyBen/super_docopt)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2ca07d88e6f7b0b57e82/maintainability)](https://codeclimate.com/github/DannyBen/super_docopt/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/2ca07d88e6f7b0b57e82/test_coverage)](https://codeclimate.com/github/DannyBen/super_docopt/test_coverage)
 
 ---
 

--- a/super_docopt.gemspec
+++ b/super_docopt.gemspec
@@ -14,15 +14,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['README.md', 'lib/**/*.*']
   s.homepage    = 'https://github.com/DannyBen/super_docopt'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'docopt', '~> 0.6'
-
-  s.add_development_dependency 'runfile', '~> 0.10'
-  s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'rspec', '~> 3.6'
-  s.add_development_dependency 'rspec_fixtures', '~> 0.3'
-  s.add_development_dependency 'simplecov', '~> 0.15'
-  s.add_development_dependency 'byebug', '~> 9.0'
-  s.add_development_dependency 'requires', '~> 0.1'
 end


### PR DESCRIPTION
- Add Ruby 2.6 to test matrix
- Remove Code Climate coverage test
- Increase minimum required Ruby to 2.3
- Move dev dependencies from gemspec to Gemfile